### PR TITLE
models.py: absolute import layers.GraphConvolution

### DIFF
--- a/pygcn/models.py
+++ b/pygcn/models.py
@@ -1,6 +1,6 @@
 import torch.nn as nn
 import torch.nn.functional as F
-from layers import GraphConvolution
+from pygcn.layers import GraphConvolution
 
 
 class GCN(nn.Module):


### PR DESCRIPTION
The relative import statement fails when pygcn is installed and used as a package. Using the absolute import (like in train.py) lets the program be run in any context.