### PR TITLE
Allow Using as a Module

### DIFF
--- a/pygcn/__init__.py
+++ b/pygcn/__init__.py
@@ -1,2 +1,6 @@
 from __future__ import print_function
 from __future__ import division
+
+from .layers import *
+from .models import *
+from .utils import *


### PR DESCRIPTION
I would like to use pip to install and use pygcn, but I was unable to do so without the package level imports I added here. This makes it really easy to use the library for example with `pip install git+https://github.com/tkipf/pygcn.git`.

Also you should consider publishing this in pypi to make it even easier.