### PR TITLE
Update train.py

### DIFF
--- a/pygcn/train.py
+++ b/pygcn/train.py
@@ -14,7 +14,7 @@ from pygcn.models import GCN
 
 # Training settings
 parser = argparse.ArgumentParser()
-parser.add_argument('--no-cuda', action='store_true', default=False,
+parser.add_argument('--no_cuda', action='store_true', default=False,
                     help='Disables CUDA training.')
 parser.add_argument('--fastmode', action='store_true', default=False,
                     help='Validate during training pass.')


### PR DESCRIPTION
Hello Thomas, supreme work!
I think the change I made may make it less confusing for a beginner like me.
`arg.no-cuda` is illegal in syntax while `arg.no_cuda` is the correct way to call the attribute value.
I don't know why but I think it will be more clear to name the attribute `no_cuda`.
