### PR TITLE
Freeze model performance

### DIFF
--- a/pygcn/utils.py
+++ b/pygcn/utils.py
@@ -4,7 +4,7 @@ import torch
 
 
 def encode_onehot(labels):
-    classes = set(labels)
+    classes = sorted(set(labels))
     classes_dict = {c: np.identity(len(classes))[i, :] for i, c in
                     enumerate(classes)}
     labels_onehot = np.array(list(map(classes_dict.get, labels)),


### PR DESCRIPTION
Freeze model performance in multiple training process.
The simplest way is to freeze one-hot encoding for each class every time we re-run the train.py.
By applying this, we can freeze the model performance to 0.8250 with loss 0.7380.