### PR TITLE
Sort the one-hot-encoding for reproducible results

### DIFF
--- a/pygcn/utils.py
+++ b/pygcn/utils.py
@@ -6,7 +6,7 @@ import torch
 def encode_onehot(labels):
     classes = set(labels)
     classes_dict = {c: np.identity(len(classes))[i, :] for i, c in
-                    enumerate(classes)}
+                    enumerate(sorted(classes))}
     labels_onehot = np.array(list(map(classes_dict.get, labels)),
                              dtype=np.int32)
     return labels_onehot


### PR DESCRIPTION
To #58, the results are not reproducible. It's caused by the one-hot encoding for the label while loading the data. We can get reproducible results after fixing the class order.